### PR TITLE
Nova seção "Papéis da SouJunior" na página Home 

### DIFF
--- a/src/pages/home/view/index.tsx
+++ b/src/pages/home/view/index.tsx
@@ -31,10 +31,16 @@ import {
   HomeContainer,
   HomeContent,
   HomeTextContent,
+  JoinButton,
   TestimonialAuthor,
   TestimonialCard,
   TestimonialColumn,
   Toothpick,
+  SectionTitle,
+  TextContainer,
+  SectionText,
+  PapersContainer,
+  ToothpickPapers,
 } from './styles';
 import { HOME_TESTIMONIALS } from './testimonialsData';
 
@@ -356,6 +362,98 @@ const HomeView = () => {
         />
       </section>
 
+      <AreasContainer>
+        <AreasContent>
+          <AreasTextContent>
+            <SectionTitle>
+              Faça você também parte da nossa comunidade!
+            </SectionTitle>
+
+            <SectionText>
+              Na SouJunior, há diversas maneiras de participar:
+            </SectionText>
+            <div
+              style={{
+                minHeight: '12.31rem',
+              }}
+            >
+              <PapersContainer>
+                <TextContainer>
+                  <Text
+                    size={24}
+                    color="#002C66"
+                    weight={500}
+                    textAlign="center"
+                  >
+                    Júnior
+                  </Text>
+                  <Text
+                    size={16}
+                    color="#000000"
+                    weight={400}
+                    textAlign="center"
+                    marginBlock={0}
+                  >
+                    Júnior executa tarefas do projeto enquanto aprende na
+                    prática e desenvolve habilidades, sempre sob orientação de
+                    mentores e heads.
+                  </Text>
+                </TextContainer>
+                <ToothpickPapers />
+                <TextContainer>
+                  <Text
+                    size={24}
+                    color="#002C66"
+                    weight={500}
+                    textAlign="center"
+                  >
+                    Mentor
+                  </Text>
+                  <Text
+                    size={16}
+                    color="#000000"
+                    weight={400}
+                    textAlign="center"
+                    marginBlock={0}
+                  >
+                    Mentor orienta, tira dúvidas e apoia o crescimento dos
+                    juniores dentro de cada área de atuação.
+                  </Text>
+                </TextContainer>
+                <ToothpickPapers />
+                <TextContainer>
+                  <Text
+                    size={24}
+                    color="#002C66"
+                    weight={500}
+                    textAlign="center"
+                  >
+                    Head
+                  </Text>
+                  <Text
+                    size={16}
+                    color="#000000"
+                    weight={400}
+                    marginBlock={0}
+                    textAlign="center"
+                  >
+                    Head organiza e lidera equipes, toma decisões e garante que
+                    tudo funcione bem dentro do projeto.
+                  </Text>
+                </TextContainer>
+              </PapersContainer>
+              <JoinButton
+                href="https://stars.soujunior.tech/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Participar
+              </JoinButton>
+            </div>
+          </AreasTextContent>
+        </AreasContent>
+      </AreasContainer>
+
       <section
         id="nossas-iniciativas"
         aria-label="Nossas iniciativas"
@@ -364,7 +462,13 @@ const HomeView = () => {
           maxWidth: '1440px',
         }}
       >
-        <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
+        <div
+          style={{
+            textAlign: 'center',
+            marginBottom: '2rem',
+            marginTop: '2.56rem',
+          }}
+        >
           <Title
             as="h2"
             color="#001633"

--- a/src/pages/home/view/styles.ts
+++ b/src/pages/home/view/styles.ts
@@ -77,6 +77,10 @@ export const AreasContainer = styled.div`
   justify-content: center;
   user-select: none;
   margin-top: 20px;
+
+  @media (max-width: 606px) {
+    padding: 20px 0 10px 0;
+  }
 `;
 
 export const AreasContent = styled.div`
@@ -117,4 +121,89 @@ export const CustomCardWrapper = styled.div`
   border-radius: 24px;
   background-color: #fff;
   max-width: 600px;
+`;
+
+export const SectionTitle = styled.h2`
+  color: #003986;
+  font-size: 2.5rem;
+  text-align: center;
+  margin-bottom: 1.25rem;
+  margin-top: 0.625rem;
+
+  @media (max-width: 606px) {
+    font-size: 1.5rem;
+    margin-top: 0.25rem;
+  }
+`;
+
+export const SectionText = styled.p`
+  marginblock: '0';
+  font-size: 1rem;
+  color: #323232;
+  text-align: center;
+  margin-bottom: 1rem;
+
+  @media (max-width: 606px) {
+    width: 100%;
+    text-align: start;
+    margin-left: 1rem;
+  }
+`;
+
+export const PapersContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+
+  @media (max-width: 606px) {
+    flex-direction: column;
+  }
+`;
+
+export const TextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 270px;
+  height: 129px;
+
+  @media (max-width: 606px) {
+    width: 100%;
+    min-width: 406px;
+    height: auto;
+    padding: 0 0.5rem;
+  }
+`;
+
+export const ToothpickPapers = styled.div`
+  width: 1px;
+  height: 3.125rem;
+  background-color: #acacac;
+  margin: 1rem 1.5rem;
+
+  @media (max-width: 606px) {
+    height: 1px;
+    width: 3.125rem;
+    margin-top: 2rem;
+  }
+`;
+
+export const JoinButton = styled.a`
+  width: 121px;
+  height: 44px;
+  border-radius: 10px;
+  color: white;
+  background-color: #003986;
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  margin-top: 1.56rem;
+  margin-bottom: 2rem;
+
+  @media (max-width: 606px) {
+    margin-bottom: 1rem;
+  }
 `;

--- a/src/pages/home/view/styles.ts
+++ b/src/pages/home/view/styles.ts
@@ -137,7 +137,6 @@ export const SectionTitle = styled.h2`
 `;
 
 export const SectionText = styled.p`
-  marginblock: '0';
   font-size: 1rem;
   color: #323232;
   text-align: center;
@@ -169,7 +168,6 @@ export const TextContainer = styled.div`
 
   @media (max-width: 606px) {
     width: 100%;
-    min-width: 406px;
     height: auto;
     padding: 0 0.5rem;
   }

--- a/src/pages/home/view/styles.ts
+++ b/src/pages/home/view/styles.ts
@@ -168,6 +168,7 @@ export const TextContainer = styled.div`
 
   @media (max-width: 606px) {
     width: 100%;
+    max-width: 420px;
     height: auto;
     padding: 0 0.5rem;
   }


### PR DESCRIPTION
**Descrição**

Esse PR visa inserir na Home a seção "Papéis da SouJunior", onde o usuário poderá verificar os diferentes papéis na SouJunior e escolher qual deseja desempenhar clicando no botão Participar. 

**Alterações Principais**
Adicionar após a seção "Depoimentos", a seção "Papéis da SouJunior", com um botão "Participar". Esse botão, quando clicado, está redirecionando o usuário para o link: https://stars.soujunior.tech/.

Versão Desktop: 

<img width="2560" height="1261" alt="image" src="https://github.com/user-attachments/assets/11b775c9-ab1a-41f2-ae02-fa32eaae71fe" />

Versão Mobile: 

<img width="613" height="1069" alt="image" src="https://github.com/user-attachments/assets/06e6ef6d-c29f-4d92-91f6-b8eac64c7b9f" />






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Novas Funcionalidades**
  * Adicionada nova seção na página inicial apresentando como participar da comunidade com descrições de papéis disponíveis (Júnior, Mentor, Head)
  * Incluído botão de inscrição na comunidade
  * Melhorado espaçamento no layout da página
  * Implementado design responsivo para dispositivos móveis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->