### PR TITLE
feat: Removal of the Our Initiatives section and addition of a link t…

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -32,11 +32,13 @@ function Footer() {
     >
       <FooterContainer>
         <Logo>
-          <Image
-            src={logoImage}
-            alt="Sou Junior - Logo da organização que impulsiona carreiras em tecnologia"
-            role="img"
-          />
+          <a href="/">
+            <Image
+              src={logoImage}
+              alt="Sou Junior - Logo da organização que impulsiona carreiras em tecnologia"
+              role="img"
+            />
+          </a>
         </Logo>
         <NavContainer>
           <ContentWrapper>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import {
   FooterContainer,
   Nav,
@@ -32,13 +33,13 @@ function Footer() {
     >
       <FooterContainer>
         <Logo>
-          <a href="/">
+          <RouterLink to="/">
             <Image
               src={logoImage}
               alt="Sou Junior - Logo da organização que impulsiona carreiras em tecnologia"
               role="img"
             />
-          </a>
+          </RouterLink>
         </Logo>
         <NavContainer>
           <ContentWrapper>

--- a/src/components/ourInitiatives/index.tsx
+++ b/src/components/ourInitiatives/index.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { CardsWrapper, CustomCardWrapper } from './ourInitiatives.styles';
+import Title from '../../components/.global/title';
+import Card from '../card';
+
+import IconLabs from '@assets/icon-labs.png';
+import IconTalk from '@assets/icon-talk.png';
+
+function OurInitiatives() {
+  return (
+    <>
+      <section
+        id="nossas-iniciativas"
+        aria-label="Nossas iniciativas"
+        style={{
+          margin: 'auto',
+          maxWidth: '1440px',
+        }}
+      >
+        <div
+          style={{
+            textAlign: 'center',
+            marginBottom: '2rem',
+            marginTop: '2.56rem',
+          }}
+        >
+          <Title
+            as="h2"
+            color="#001633"
+            size={48}
+            fontWeight={700}
+            textAlign="center"
+            marginBottom={0}
+          >
+            Nossas iniciativas
+          </Title>
+        </div>
+        <CardsWrapper>
+          <CustomCardWrapper>
+            <Card
+              width={598}
+              height={267}
+              marginBlock="0"
+              title="SouJunior Labs"
+              description={
+                <>
+                  Coloque em prática suas expertises em projetos reais, e ganhe
+                  experiência no mercado de trabalho.
+                </>
+              }
+              titleSize={24}
+              titleColor="#003986"
+              titleListWeight={600}
+              descriptionSize={16}
+              descriptionWeight={400}
+              descriptionColor="#000000"
+              imageSrc={IconLabs}
+              imageHeight={235}
+              imageWidth={235}
+              flexDirection="row-reverse"
+              buttonText="Acesse"
+              buttonVariant="outline"
+              onClick={() =>
+                window.open(
+                  'https://docs.google.com/forms/d/e/1FAIpQLSd1IspO3Hwylce2kHtIsmyBAkH7p3VFmdYUmdL75YXZ-DSNBA/viewform',
+                  '_blank',
+                )
+              }
+            />
+          </CustomCardWrapper>
+          <CustomCardWrapper>
+            <Card
+              width={598}
+              height={267}
+              marginBlock="0"
+              title="SouJunior Talk"
+              description={
+                <>
+                  Se você está procurando uma maneira de aprimorar seu inglês
+                  com pessoas reais, temos uma excelente notícia para você!
+                </>
+              }
+              titleSize={24}
+              titleColor="#003986"
+              titleListWeight={520}
+              descriptionSize={16}
+              descriptionWeight={400}
+              descriptionColor="#000000"
+              imageSrc={IconTalk}
+              imageHeight={235}
+              imageWidth={235}
+              flexDirection="row-reverse"
+              buttonText="Acesse"
+              buttonVariant="outline"
+              onClick={() =>
+                window.open('https://discord.com/invite/564CDre9F3', '_blank')
+              }
+            />
+          </CustomCardWrapper>
+        </CardsWrapper>
+      </section>
+    </>
+  );
+}
+
+export default OurInitiatives;

--- a/src/components/ourInitiatives/ourInitiatives.styles.ts
+++ b/src/components/ourInitiatives/ourInitiatives.styles.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const CardsWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 32px;
+  flex-wrap: wrap;
+`;
+
+export const CustomCardWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 53px;
+  border: 1px solid #002c66;
+  border-radius: 24px;
+  background-color: #fff;
+  max-width: 600px;
+`;

--- a/src/pages/home/view/index.tsx
+++ b/src/pages/home/view/index.tsx
@@ -595,13 +595,9 @@ const HomeView = () => {
         </div>
 
         <NewsAndEventsCarousel items={carouselNewsEvents} />
-
-        <hr
-          style={{ width: '600px', marginTop: '3rem', marginInline: 'auto' }}
-        />
       </section>
 
-      <section
+      {/* <section
         id="nossas-iniciativas"
         aria-label="Nossas iniciativas"
         style={{
@@ -691,10 +687,13 @@ const HomeView = () => {
           </CustomCardWrapper>
         </CardsWrapper>
         <Divider />
-      </section>
+      </section> */}
+
       <div style={{ position: 'relative' }}>
         <SuporterContainer id="seja-um-apoiador">
           <SuporterContent>
+            <Divider />
+
             <SuporterTitle>Seja um Apoiador!</SuporterTitle>
             <Text
               size={16}

--- a/src/pages/home/view/index.tsx
+++ b/src/pages/home/view/index.tsx
@@ -18,8 +18,6 @@ import IconQA from '../../../assets/icon-qa.png';
 import IconDevOps from '../../../assets/icon-devops.png';
 import SkillsCarousel from '../../../components/skills.carousel';
 import type { SkillItem } from '../../../components/skills.carousel';
-import IconLabs from '@assets/icon-labs.png';
-import IconTalk from '@assets/icon-talk.png';
 import type { Item as CarouselNewsEventsItem } from '@components/newsAndEvents.carousel/index';
 import { NewsAndEventsCarousel } from '@components/newsAndEvents.carousel/index';
 import ExperienciaTransformaDia1 from '@assets/news-events/experiencia-que-transforma/dia1.png';
@@ -39,9 +37,7 @@ import {
   AreasContainer,
   AreasContent,
   AreasTextContent,
-  CardsWrapper,
   CarouselContainer,
-  CustomCardWrapper,
   HomeButton,
   HomeContainer,
   HomeContent,
@@ -596,98 +592,6 @@ const HomeView = () => {
 
         <NewsAndEventsCarousel items={carouselNewsEvents} />
       </section>
-
-      {/* <section
-        id="nossas-iniciativas"
-        aria-label="Nossas iniciativas"
-        style={{
-          margin: 'auto',
-          maxWidth: '1440px',
-        }}
-      >
-        <div
-          style={{
-            textAlign: 'center',
-            marginBottom: '2rem',
-            marginTop: '2.56rem',
-          }}
-        >
-          <Title
-            as="h2"
-            color="#001633"
-            size={48}
-            fontWeight={700}
-            textAlign="center"
-            marginBottom={0}
-          >
-            Nossas iniciativas
-          </Title>
-        </div>
-        <CardsWrapper>
-          <CustomCardWrapper>
-            <Card
-              width={598}
-              height={267}
-              marginBlock="0"
-              title="SouJunior Labs"
-              description={
-                <>
-                  Coloque em prática suas expertises em projetos reais, e ganhe
-                  experiência no mercado de trabalho.
-                </>
-              }
-              titleSize={24}
-              titleColor="#003986"
-              titleListWeight={600}
-              descriptionSize={16}
-              descriptionWeight={400}
-              descriptionColor="#000000"
-              imageSrc={IconLabs}
-              imageHeight={235}
-              imageWidth={235}
-              flexDirection="row-reverse"
-              buttonText="Acesse"
-              buttonVariant="outline"
-              onClick={() =>
-                window.open(
-                  'https://docs.google.com/forms/d/e/1FAIpQLSd1IspO3Hwylce2kHtIsmyBAkH7p3VFmdYUmdL75YXZ-DSNBA/viewform',
-                  '_blank',
-                )
-              }
-            />
-          </CustomCardWrapper>
-          <CustomCardWrapper>
-            <Card
-              width={598}
-              height={267}
-              marginBlock="0"
-              title="SouJunior Talk"
-              description={
-                <>
-                  Se você está procurando uma maneira de aprimorar seu inglês
-                  com pessoas reais, temos uma excelente notícia para você!
-                </>
-              }
-              titleSize={24}
-              titleColor="#003986"
-              titleListWeight={520}
-              descriptionSize={16}
-              descriptionWeight={400}
-              descriptionColor="#000000"
-              imageSrc={IconTalk}
-              imageHeight={235}
-              imageWidth={235}
-              flexDirection="row-reverse"
-              buttonText="Acesse"
-              buttonVariant="outline"
-              onClick={() =>
-                window.open('https://discord.com/invite/564CDre9F3', '_blank')
-              }
-            />
-          </CustomCardWrapper>
-        </CardsWrapper>
-        <Divider />
-      </section> */}
 
       <div style={{ position: 'relative' }}>
         <SuporterContainer id="seja-um-apoiador">

--- a/src/pages/home/view/styles.ts
+++ b/src/pages/home/view/styles.ts
@@ -294,14 +294,15 @@ export const JoinButton = styled.a`
 `;
 
 export const SuporterContainer = styled.div`
-  padding: 60px 0 40px 0;
+  padding: 0 0 40px 0;
   display: flex;
   justify-content: center;
   user-select: none;
   margin-top: 20px;
+  background-color: #e6e6e6;
 
   @media (max-width: 430px) {
-    padding: 16px 24px 16px 24px;
+    padding: 0 24px 16px 24px;
   }
 `;
 

--- a/src/pages/home/view/styles.ts
+++ b/src/pages/home/view/styles.ts
@@ -192,23 +192,6 @@ export const CarouselContainer = styled.div`
   max-width: 935px;
 `;
 
-export const CardsWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  gap: 32px;
-  flex-wrap: wrap;
-`;
-
-export const CustomCardWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 53px;
-  border: 1px solid #002c66;
-  border-radius: 24px;
-  background-color: #fff;
-  max-width: 600px;
-`;
-
 export const SectionTitle = styled.h2`
   color: #003986;
   font-size: 2.5rem;

--- a/src/utils/footerLinks.ts
+++ b/src/utils/footerLinks.ts
@@ -26,10 +26,10 @@ const footerLinks = [
     label: 'Missão, Valores e Visão',
     to: LinkFooterEnum.MISSION_VALUES_VISION.toString(),
   },
-  {
-    label: 'Nossas Iniciativas',
-    to: LinkFooterEnum.INITIATIVES.toString(),
-  },
+  // {
+  //   label: 'Nossas Iniciativas',
+  //   to: LinkFooterEnum.INITIATIVES.toString(),
+  // },
 ];
 
 const footerLinks2 = [

--- a/src/utils/headerLinks.ts
+++ b/src/utils/headerLinks.ts
@@ -32,12 +32,12 @@ export const createHeaderLinks = (navigate: (route: RouteEnum) => void) => {
         ariaLabel: 'Navegar para a página Sobre Nós',
         route: RouteEnum.ABOUT_US,
       },
-      {
-        label: 'initiatives',
-        onClick: () => handleAnchorClick(RouteEnum.INITIATIVES),
-        ariaLabel: 'Navegar para a página Nossas Iniciativas',
-        route: RouteEnum.INITIATIVES,
-      },
+      // {
+      //   label: 'initiatives',
+      //   onClick: () => handleAnchorClick(RouteEnum.INITIATIVES),
+      //   ariaLabel: 'Navegar para a página Nossas Iniciativas',
+      //   route: RouteEnum.INITIATIVES,
+      // },
       {
         label: 'newsAndEvents',
         onClick: () => handleAnchorClick(RouteEnum.NEWS_AND_EVENTS),

--- a/tests/unit/components/header/index.test.tsx
+++ b/tests/unit/components/header/index.test.tsx
@@ -24,7 +24,7 @@ describe('Header Component', () => {
   it('should match snapshot', () => {
     const links = [
       { label: 'aboutUs', onClick: jest.fn() },
-      { label: 'initiatives', onClick: jest.fn() },
+      // { label: 'initiatives', onClick: jest.fn() },
     ];
 
     const { container } = render(

--- a/tests/unit/components/header/index.test.tsx
+++ b/tests/unit/components/header/index.test.tsx
@@ -1,36 +1,36 @@
-import React from "react";
-import { render } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
-import Header from "../../../../src/components/header";
-import "@testing-library/jest-dom";
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Header from '../../../../src/components/header';
+import '@testing-library/jest-dom';
 
-describe("Header Component", () => {
-  it("should render correctly", () => {
+describe('Header Component', () => {
+  it('should render correctly', () => {
     const links = [
-      { label: "Sobre nós", to: "/about", onClick: jest.fn() },
-      { label: "Nossas iniciativas", to: "/initiatives", onClick: jest.fn() },
+      { label: 'Sobre nós', to: '/about', onClick: jest.fn() },
+      // { label: "Nossas iniciativas", to: "/initiatives", onClick: jest.fn() },
     ];
 
     const { getByAltText, getByText } = render(
       <MemoryRouter>
         <Header links={links} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
-    expect(getByAltText("Sou Junior Logo")).toBeInTheDocument();
-    expect(getByText("links.Sobre nós")).toBeInTheDocument();
-    expect(getByText("links.Nossas iniciativas")).toBeInTheDocument();
+    expect(getByAltText('Sou Junior Logo')).toBeInTheDocument();
+    expect(getByText('links.Sobre nós')).toBeInTheDocument();
+    // expect(getByText("links.Nossas iniciativas")).toBeInTheDocument();
   });
 
-  it("should match snapshot", () => {
+  it('should match snapshot', () => {
     const links = [
-      { label: "aboutUs", onClick: jest.fn() },
-      { label: "initiatives", onClick: jest.fn() },
+      { label: 'aboutUs', onClick: jest.fn() },
+      { label: 'initiatives', onClick: jest.fn() },
     ];
 
     const { container } = render(
       <MemoryRouter>
         <Header links={links} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(container.firstChild).toMatchSnapshot();


### PR DESCRIPTION
Descrição

Ocultaçaõ da seção "Nossas Iniciativas"

Alterações Principais
Adição de comentários na seção "Nossas Iniciativas" ou botões/links que redirecionassem a essa tela

Observação:
Conforme proposto, a seção foi apenas comentada, pois quando preciso, ela será reativada. 

<img width="2560" height="1265" alt="image" src="https://github.com/user-attachments/assets/9ae6d730-dce5-401d-b07f-f07bfa3c6b36" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novas funcionalidades**
  * Adicionada a seção “Nossas iniciativas”, com cards para “SouJunior Labs” e “SouJunior Talk”.
  * Os botões direcionam para formulários e comunidades externas em uma nova aba.
  * O logo do rodapé agora direciona para a página inicial.

* **Alterações**
  * Removidos os links de “Nossas iniciativas” do cabeçalho e rodapé.
  * Ajustado o espaçamento da seção “Seja um Apoiador!” em diferentes tamanhos de tela.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->