### PR TITLE
Ajustar carrossel das páginas das áreas de atuação

### DIFF
--- a/src/components/carouselAreaOperation/carousel.styles.ts
+++ b/src/components/carouselAreaOperation/carousel.styles.ts
@@ -1,0 +1,97 @@
+import styled from 'styled-components';
+
+export const CarouselContainer = styled.div`
+  padding: 10px 0;
+  position: relative;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  overflow: hidden;
+`;
+
+export const CardWrapper = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  overflow: hidden;
+
+  .left {
+    position: absolute;
+    left: -70px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .right {
+    position: absolute;
+    right: -70px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  @media (max-width: 440px) {
+    padding: 0 12px;
+    box-sizing: border-box;
+  }
+`;
+
+export const ArrowButton = styled.button<{
+  disabled?: boolean;
+  $side?: 'left' | 'right';
+}>`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+
+  ${({ $side }) => ($side === 'left' ? 'left: 200px;' : 'right: 200px;')}
+
+  width: 16px;
+  height: 16px;
+
+  border: none;
+  background: transparent;
+  cursor: pointer;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  z-index: 20;
+
+  svg {
+    width: 28px;
+    height: 28px;
+    stroke: #323232;
+  }
+
+  @media (max-width: 440px) {
+    display: none;
+  }
+`;
+
+export const Dots = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 24px;
+
+  @media (max-width: 440px) {
+    display: none;
+  }
+`;
+
+export const Dot = styled.button<{ active: boolean }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+
+  background: ${({ active }) => (active ? '#338AFF' : '#D9D9D9')};
+
+  cursor: pointer;
+`;

--- a/src/components/carouselAreaOperation/carousel.styles.ts
+++ b/src/components/carouselAreaOperation/carousel.styles.ts
@@ -9,6 +9,14 @@ export const CarouselContainer = styled.div`
   align-items: center;
 
   overflow: hidden;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: none;
+  }
 `;
 
 export const CardWrapper = styled.div`
@@ -85,13 +93,13 @@ export const Dots = styled.div`
   }
 `;
 
-export const Dot = styled.button<{ active: boolean }>`
+export const Dot = styled.button<{ $active: boolean }>`
   width: 8px;
   height: 8px;
   border-radius: 50%;
   border: none;
 
-  background: ${({ active }) => (active ? '#338AFF' : '#D9D9D9')};
+  background: ${({ $active }) => ($active ? '#338AFF' : '#D9D9D9')};
 
   cursor: pointer;
 `;

--- a/src/components/carouselAreaOperation/index.tsx
+++ b/src/components/carouselAreaOperation/index.tsx
@@ -1,0 +1,141 @@
+import React, { useRef, useState, useEffect } from 'react';
+import {
+  CarouselContainer,
+  ArrowButton,
+  Dots,
+  Dot,
+  CardWrapper,
+} from './carousel.styles';
+import CarouselFeatureCard from '@components/carouselFeatureCard';
+
+export interface CarouselItem {
+  id?: string | number;
+  img?: string;
+  title?: string;
+  subtitle?: string;
+  description?: string;
+  list?: string[];
+  quote?: string;
+  name?: string;
+  role?: string;
+  avatarSrc?: string;
+  avatarAlt?: string;
+}
+
+export interface CarouselProps {
+  items: CarouselItem[];
+  renderItem?: (item: CarouselItem, index: number) => React.ReactNode;
+
+  itemWidth?: number;
+}
+
+const CarouselAreaOperation: React.FC<CarouselProps> = ({
+  items,
+  itemWidth = 354,
+}) => {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const [canScrollPrev, setCanScrollPrev] = useState(false);
+  const [canScrollNext, setCanScrollNext] = useState(true);
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const next = () => {
+    setCurrentIndex((prev) => (prev === items.length - 1 ? 0 : prev + 1));
+  };
+
+  const prev = () => {
+    if (currentIndex > 0) {
+      setCurrentIndex((prev) => prev - 1);
+    }
+  };
+
+  const handleScroll = () => {
+    const el = wrapperRef.current;
+    if (!el) return;
+
+    const isAtStart = el.scrollLeft <= 5;
+    const isAtEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 5;
+
+    setCanScrollPrev(!isAtStart);
+    setCanScrollNext(!isAtEnd);
+  };
+
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+
+    handleScroll(); // Initial check
+
+    el.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('resize', handleScroll);
+
+    // After mount, verify dimensions because DOM sizing can be delayed
+    setTimeout(handleScroll, 100);
+
+    return () => {
+      el.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleScroll);
+    };
+  }, [items]);
+
+  const scrollByPage = (direction: 'next' | 'prev') => {
+    const el = wrapperRef.current;
+    if (!el) return;
+
+    const gap = 24;
+    const cardWidth = itemWidth + gap;
+    // Scroll intentionally by exactly 3 cards for an entire new session
+    const scrollAmount =
+      direction === 'next' ? cardWidth * 3 : -(cardWidth * 3);
+
+    el.scrollBy({ left: scrollAmount, behavior: 'smooth' });
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowRight' && canScrollNext) {
+      e.preventDefault();
+      scrollByPage('next');
+    } else if (e.key === 'ArrowLeft' && canScrollPrev) {
+      e.preventDefault();
+      scrollByPage('prev');
+    }
+  };
+
+  return (
+    <CarouselContainer
+      onKeyDown={onKeyDown}
+      tabIndex={0}
+      aria-roledescription="carousel"
+    >
+      <CardWrapper>
+        {currentIndex > 0 && (
+          <ArrowButton $side="left" onClick={prev} aria-label="Anterior">
+            <svg width="32" height="32" viewBox="0 0 24 24">
+              <polyline points="15 18 9 12 15 6" fill="none" strokeWidth="2" />
+            </svg>
+          </ArrowButton>
+        )}
+
+        <CarouselFeatureCard {...items[currentIndex]} />
+
+        <ArrowButton $side="right" onClick={next} aria-label="Próximo">
+          <svg width="32" height="32" viewBox="0 0 24 24">
+            <polyline points="9 18 15 12 9 6" fill="none" strokeWidth="2" />
+          </svg>
+        </ArrowButton>
+      </CardWrapper>
+
+      <Dots>
+        {items.map((_, index) => (
+          <Dot
+            key={index}
+            active={index === currentIndex}
+            onClick={() => setCurrentIndex(index)}
+          />
+        ))}
+      </Dots>
+    </CarouselContainer>
+  );
+};
+
+export default CarouselAreaOperation;

--- a/src/components/carouselAreaOperation/index.tsx
+++ b/src/components/carouselAreaOperation/index.tsx
@@ -78,26 +78,13 @@ const CarouselAreaOperation: React.FC<CarouselProps> = ({
     };
   }, [items]);
 
-  const scrollByPage = (direction: 'next' | 'prev') => {
-    const el = wrapperRef.current;
-    if (!el) return;
-
-    const gap = 24;
-    const cardWidth = itemWidth + gap;
-    // Scroll intentionally by exactly 3 cards for an entire new session
-    const scrollAmount =
-      direction === 'next' ? cardWidth * 3 : -(cardWidth * 3);
-
-    el.scrollBy({ left: scrollAmount, behavior: 'smooth' });
-  };
-
   const onKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowRight' && canScrollNext) {
+    if (e.key === 'ArrowRight') {
       e.preventDefault();
-      scrollByPage('next');
-    } else if (e.key === 'ArrowLeft' && canScrollPrev) {
+      next();
+    } else if (e.key === 'ArrowLeft') {
       e.preventDefault();
-      scrollByPage('prev');
+      prev();
     }
   };
 
@@ -129,7 +116,9 @@ const CarouselAreaOperation: React.FC<CarouselProps> = ({
         {items.map((_, index) => (
           <Dot
             key={index}
-            active={index === currentIndex}
+            $active={index === currentIndex}
+            aria-label={`Ir para o cartão ${index + 1}`}
+            aria-current={index === currentIndex ? 'true' : undefined}
             onClick={() => setCurrentIndex(index)}
           />
         ))}

--- a/src/components/carouselFeatureCard/carousel-feature-card.styles.ts
+++ b/src/components/carouselFeatureCard/carousel-feature-card.styles.ts
@@ -4,6 +4,8 @@ export const CardContainer = styled.article`
   display: flex;
   align-items: stretch;
   gap: 32px;
+  flex-shrink: 0;
+  scroll-snap-align: center;
 
   max-width: 1042px;
   width: 100%;
@@ -16,6 +18,11 @@ export const CardContainer = styled.article`
   background: #fff;
 
   box-sizing: border-box;
+
+  &:focus,
+  &:focus-visible {
+    outline: none;
+  }
 
   @media (max-width: 440px) {
     flex-direction: column;
@@ -133,7 +140,7 @@ export const StyledListItem = styled.li`
   leading-trim: NONE;
   line-height: 140%;
   letter-spacing: 0%;
-  color: ##000000;
+  color: #000000;
   margin-bottom: 2px;
 
   &::marker {

--- a/src/components/carouselFeatureCard/carousel-feature-card.styles.ts
+++ b/src/components/carouselFeatureCard/carousel-feature-card.styles.ts
@@ -1,0 +1,147 @@
+import styled from 'styled-components';
+
+export const CardContainer = styled.article`
+  display: flex;
+  align-items: stretch;
+  gap: 32px;
+
+  max-width: 1042px;
+  width: 100%;
+  height: 434px;
+
+  padding: 30px;
+
+  border: 1px solid #338aff;
+  border-radius: 20px;
+  background: #fff;
+
+  box-sizing: border-box;
+
+  @media (max-width: 440px) {
+    flex-direction: column;
+    align-items: flex-start;
+
+    width: 290px;
+    min-height: 521px;
+
+    padding: 16px;
+    gap: 24px;
+
+    border-radius: 15px;
+    border-width: 0.75px;
+  }
+
+  @media (max-width: 400px) {
+    width: calc(100% - 24px);
+  }
+`;
+
+export const ImageContainer = styled.div`
+  flex: 0 0 42%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  img {
+    width: 100%;
+    max-width: 450px;
+    height: auto;
+    object-fit: contain;
+  }
+
+  @media (max-width: 440px) {
+    width: 100%;
+    flex: none;
+
+    img {
+      max-width: 253.12px;
+    }
+  }
+
+  @media (max-width: 400px) {
+    img {
+      max-width: 220px;
+    }
+  }
+`;
+
+export const Content = styled.div`
+  flex: 1;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+
+  @media (max-width: 440px) {
+    width: 100%;
+    margin-top: 0;
+  }
+`;
+
+export const CardTitle = styled.h3`
+  font-weight: 500;
+  font-style: Medium;
+  font-size: 24px;
+  leading-trim: NONE;
+  line-height: 120%;
+  letter-spacing: 0%;
+  color: #003986;
+  padding-top: 60px;
+
+  @media (max-width: 440px) {
+    width: 100%;
+    font-size: 18px;
+    text-align: left;
+    padding-top: 0;
+  }
+
+  @media (max-width: 400px) {
+    font-size: 18px;
+  }
+`;
+
+export const CardParagraph = styled.p`
+  font-weight: 400;
+  font-style: Regular;
+  font-size: 16px;
+  leading-trim: NONE;
+  line-height: 140%;
+  letter-spacing: 0%;
+  color: #000000;
+  margin: 20px 0;
+
+  @media (max-width: 440px) {
+    font-size: 12px;
+    margin: 16px 0;
+  }
+`;
+
+export const StyledList = styled.ul`
+  margin: 0;
+  padding-left: 24px;
+
+  @media (max-width: 440px) {
+    padding-left: 20px;
+  }
+`;
+
+export const StyledListItem = styled.li`
+  font-weight: 400;
+  font-style: Regular;
+  font-size: 16px;
+  leading-trim: NONE;
+  line-height: 140%;
+  letter-spacing: 0%;
+  color: ##000000;
+  margin-bottom: 2px;
+
+  &::marker {
+    color: #000;
+  }
+
+  @media (max-width: 440px) {
+    font-size: 12px;
+    line-height: 150%;
+  }
+`;

--- a/src/components/carouselFeatureCard/index.tsx
+++ b/src/components/carouselFeatureCard/index.tsx
@@ -1,0 +1,39 @@
+import {
+  CardContainer,
+  ImageContainer,
+  Content,
+  CardTitle,
+  CardParagraph,
+  StyledList,
+  StyledListItem,
+} from './carousel-feature-card.styles';
+
+import type { CarouselItem } from '../carousel';
+
+const CarouselFeatureCard: React.FC<CarouselItem> = ({
+  img,
+  title,
+  description,
+  list,
+}) => {
+  return (
+    <CardContainer>
+      <ImageContainer>
+        <img src={img} alt={title} />
+      </ImageContainer>
+
+      <Content>
+        <CardTitle>{title}</CardTitle>
+        <CardParagraph>{description}</CardParagraph>
+
+        <StyledList>
+          {list?.map((item, index) => (
+            <StyledListItem key={index}>{item}</StyledListItem>
+          ))}
+        </StyledList>
+      </Content>
+    </CardContainer>
+  );
+};
+
+export default CarouselFeatureCard;

--- a/src/components/carouselFeatureCard/types.ts
+++ b/src/components/carouselFeatureCard/types.ts
@@ -1,0 +1,9 @@
+export interface CarouselFeatureCardProps {
+  image: string;
+  imageAlt?: string;
+
+  title: string;
+  description: string;
+
+  topics: string[];
+}

--- a/src/pages/area-operation/design/view/index.view.tsx
+++ b/src/pages/area-operation/design/view/index.view.tsx
@@ -13,7 +13,7 @@ import Img3 from '@assets/areas-expertise/design-carousel/img3.png';
 import Img4 from '@assets/areas-expertise/design-carousel/img4.png';
 import Card from '@components/card';
 import Button from '@global/button';
-import Carousel from '@components/carousel';
+import CarouselAreaOperation from '@components/carouselAreaOperation';
 
 const DesignView: React.FC = () => {
   const { announce } = useScreenReaderAnnouncer();
@@ -144,7 +144,7 @@ const DesignView: React.FC = () => {
           Conheça os cargos de Design que você pode explorar com a gente:
         </Title>
 
-        <Carousel items={carouselItems} />
+        <CarouselAreaOperation items={carouselItems} />
       </section>
 
       <Card

--- a/src/pages/area-operation/product/view/index.view.tsx
+++ b/src/pages/area-operation/product/view/index.view.tsx
@@ -14,7 +14,7 @@ import Img4 from '@assets/areas-expertise/product-carousel/img4.png';
 import Img5 from '@assets/areas-expertise/product-carousel/img5.png';
 import Card from '@components/card';
 import Button from '@global/button';
-import Carousel from '@components/carousel';
+import CarouselAreaOperation from '@components/carouselAreaOperation';
 
 const carouselItems = [
   {
@@ -153,7 +153,7 @@ const ProductView: React.FC = () => {
           Conheça os cargos de Produto que você pode explorar com a gente:
         </Title>
 
-        <Carousel items={carouselItems} />
+        <CarouselAreaOperation items={carouselItems} />
       </section>
 
       <Card


### PR DESCRIPTION
Descrição

Esse PR visa ajustar o bugs dos cards e seta do carrosel das páginas das áreas de atuação (Produto e Design)

Alterações Principais
Precisei criar um novo componente, a fim de separar a dinâmica dos cards e poder reaproveitar nas respectivas páginas. Foi adicionado também a responsividade para mobile. 

<img width="625" height="741" alt="bug2" src="https://github.com/user-attachments/assets/12d70e71-0cbb-4fbc-a24a-b79cf7568e3a" />
<img width="1888" height="632" alt="bug1" src="https://github.com/user-attachments/assets/147a8f3f-6022-49f6-bab9-89a52a0a7e81" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionado carrossel responsivo para exibir cartões de destaque nas áreas de Design e Produto.
  * Incluída navegação por setas, indicadores, teclado e rolagem.
  * Adicionados cartões com imagem, título, descrição e tópicos.
  * Controles e layout adaptam-se automaticamente a telas menores.
  * Melhorada a acessibilidade dos controles de navegação.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->