### PR TITLE
Ajustar a seta dos cards para telas maiores

### DIFF
--- a/src/components/carouselAreaOperation/carousel.styles.ts
+++ b/src/components/carouselAreaOperation/carousel.styles.ts
@@ -56,7 +56,10 @@ export const ArrowButton = styled.button<{
   top: 50%;
   transform: translateY(-50%);
 
-  ${({ $side }) => ($side === 'left' ? 'left: 200px;' : 'right: 200px;')}
+  ${({ $side }) =>
+    $side === 'left'
+      ? 'left: calc(50% - 521px - 30px);'
+      : 'right: calc(50% - 521px - 30px);'}
 
   width: 16px;
   height: 16px;


### PR DESCRIPTION
**Descrição**

Esse PR visa ajustar o bugs da distância das setas do carrosel das páginas das áreas de atuação (Produto e Design), levando em consideração telas maiores às de 1366px (Tamanho da tela do Figma)

**Alterações Principais**
Ajuste no cálculo da distância das setas, para posicioná-las em relação ao card. 


<img width="2532" height="721" alt="image" src="https://github.com/user-attachments/assets/6b804c3a-ba86-4778-a3ea-d736ececcbea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias visuais**
  * Ajustado o posicionamento das setas do carrossel para mantê-las alinhadas de forma mais consistente em relação ao centro da área de exibição.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->